### PR TITLE
chore: Reflect image name change, fix small typos

### DIFF
--- a/charts/udpfw/Chart.yaml
+++ b/charts/udpfw/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: udpfw
 description: A Helm chart for udpfw
 type: application
-version: 0.0.1
+version: 0.0.2
 appVersion: "v0.1-alpha2"
 sources:
   - https://github.com/udpfw/udpfw

--- a/charts/udpfw/Chart.yaml
+++ b/charts/udpfw/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 name: udpfw
-description: A Helm chart for udfpw
+description: A Helm chart for udpfw
 type: application
 version: 0.0.1
-appVersion: "v0.1-alpha1"
+appVersion: "v0.1-alpha2"
 sources:
   - https://github.com/udpfw/udpfw
 maintainers:

--- a/charts/udpfw/templates/_helpers.tpl
+++ b/charts/udpfw/templates/_helpers.tpl
@@ -36,7 +36,7 @@ Common labels
 {{- define "udpfw.labels" -}}
 helm.sh/chart: {{ include "udpfw.chart" . }}
 {{ include "udpfw.selectorLabels" . }}
-app.kubernetes.io/version: {{ .Values.udpfw.image.tag | default .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Values.global.image.tag | default .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: udpfw
 {{- with .Values.global.additionalLabels }}
@@ -67,9 +67,9 @@ Create the name of the service account to use
 {{/*
 Bind address the server will listen on
 */}}
-{{- define "udpfw.bind" -}}
-    {{ $defaultPort := (.Values.udpfw.defaultPort | int) }}
-    {{- if .Values.udpfw.bindIPV6 }}
+{{- define "dispatch.bind" -}}
+    {{ $defaultPort := (.Values.dispatch.defaultPort | int) }}
+    {{- if .Values.dispatch.bindIPV6 }}
         {{- printf "[::]:%d" $defaultPort }}
     {{- else}}
         {{- printf ":%d" $defaultPort }}
@@ -79,14 +79,14 @@ Bind address the server will listen on
 {{/*
 PubSub environment variables
 */}}
-{{- define "udpfw.pubsub-envs" -}}
-    {{- if or (and .Values.nats.enabled .Values.redis.enabled) (and .Values.udpfw.nats.url .Values.udpfw.redis.url)}}
+{{- define "dispatch.pubsub-envs" -}}
+    {{- if or (and .Values.nats.enabled .Values.redis.enabled) (and .Values.dispatch.nats.url .Values.dispatch.redis.url)}}
         {{- fail "define either NATS or Redis URL, not both." }}
     {{- end }}
-    {{- if (or .Values.udpfw.nats.url .Values.nats.enabled) }}
-        {{- include "udpfw.pubsub-envs.nats" . }}
-    {{- else if (or .Values.udpfw.redis.url .Values.redis.enabled) }}
-        {{- include "udpfw.pubsub-envs.redis" . }}
+    {{- if (or .Values.dispatch.nats.url .Values.nats.enabled) }}
+        {{- include "dispatch.pubsub-envs.nats" . }}
+    {{- else if (or .Values.dispatch.redis.url .Values.redis.enabled) }}
+        {{- include "dispatch.pubsub-envs.redis" . }}
     {{- else }}
         {{- fail "define either NATS or Redis URL." }}
     {{- end }}
@@ -95,32 +95,32 @@ PubSub environment variables
 {{/*
 PubSub NATS environment variables
 */}}
-{{- define "udpfw.pubsub-envs.nats" -}}
+{{- define "dispatch.pubsub-envs.nats" -}}
 - name: UDPFW_DISPATCH_NATS_URL
-  value: {{ .Values.udpfw.nats.url | default (printf "%s-nats:4222" (include "udpfw.fullname" . )) }}
+  value: {{ .Values.dispatch.nats.url | default (printf "%s-nats:4222" (include "udpfw.fullname" . )) }}
 - name: UDPFW_DISPATCH_NATS_SUBSCRIPTION_SUBJECT
-  value: {{ .Values.udpfw.nats.subscriptionSubject | default "udpfw-dispatch-exchange" }}
-{{- with .Values.udpfw.nats.userCredentials }}
+  value: {{ .Values.dispatch.nats.subscriptionSubject | default "udpfw-dispatch-exchange" }}
+{{- with .Values.dispatch.nats.userCredentials }}
 - name: UDPFW_DISPATCH_NATS_USER_CREDENTIALS_PATH
   value: {{ . | quote }}
 {{- end }}
-{{- with .Values.udpfw.nats.userCredentialsNkey }}
+{{- with .Values.dispatch.nats.userCredentialsNkey }}
 - name: UDPFW_DISPATCH_NATS_USER_CREDENTIALS_NKEY_PATH
   value: {{ . | quote }}
 {{- end }}
-{{- with .Values.udpfw.nats.nkeyFromSeed }}
+{{- with .Values.dispatch.nats.nkeyFromSeed }}
 - name: UDPFW_DISPATCH_NATS_NKEY_SEED_PATH
   value: {{ . | quote }}
 {{- end }}
-{{- with .Values.udpfw.nats.rootCA }}
+{{- with .Values.dispatch.nats.rootCA }}
 - name: UDPFW_DISPATCH_NATS_ROOT_CA_PATH
   value: {{ . | quote }}
 {{- end }}
-{{- with .Values.udpfw.nats.clientCertificate }}
+{{- with .Values.dispatch.nats.clientCertificate }}
 - name: UDPFW_DISPATCH_NATS_CLIENT_CERTIFICATE_PATH
   value: {{ . | quote }}
 {{- end }}
-{{- with .Values.udpfw.nats.clientKey }}
+{{- with .Values.dispatch.nats.clientKey }}
 - name: UDPFW_DISPATCH_NATS_CLIENT_CERTIFICATE_KEY_PATH
   value: {{ . | quote }}
 {{- end }}
@@ -131,7 +131,7 @@ PubSub Redis environment variables
 */}}
 {{- define "udpfw.pubsub-envs.redis" -}}
 - name: UDPFW_DISPATCH_REDIS_PATH
-  value: {{ .Values.udpfw.redis.url | default (printf "redis://%s-redis-master:6379/0" (include "udpfw.fullname" . )) }}
+  value: {{ .Values.dispatch.redis.url | default (printf "redis://%s-redis-master:6379/0" (include "udpfw.fullname" . )) }}
 - name: UDPFW_DISPATCH_REDIS_PUBSUB_CHANNEL
-  value: {{ .Values.udpfw.redis.channel | default "udpfw-dispatch-exchange" }}
+  value: {{ .Values.dispatch.redis.channel | default "udpfw-dispatch-exchange" }}
 {{- end -}}

--- a/charts/udpfw/templates/_helpers.tpl
+++ b/charts/udpfw/templates/_helpers.tpl
@@ -130,7 +130,7 @@ PubSub NATS environment variables
 PubSub Redis environment variables
 */}}
 {{- define "udpfw.pubsub-envs.redis" -}}
-- name: UDPFW_DISPATCH_REDIS_PATH
+- name: UDPFW_DISPATCH_REDIS_URL
   value: {{ .Values.dispatch.redis.url | default (printf "redis://%s-redis-master:6379/0" (include "udpfw.fullname" . )) }}
 - name: UDPFW_DISPATCH_REDIS_PUBSUB_CHANNEL
   value: {{ .Values.dispatch.redis.channel | default "udpfw-dispatch-exchange" }}

--- a/charts/udpfw/templates/daemonset.yaml
+++ b/charts/udpfw/templates/daemonset.yaml
@@ -40,50 +40,50 @@ spec:
       priorityClassName: {{ .Values.daemonset.pod.priorityClassName | default (include "udpfw.fullname" . ) }}
       {{- end }}
       containers:
-        - name: {{ .Chart.Name }}
-          image: "{{ .Values.udpfw.image.repository }}:{{ .Values.udpfw.image.tag | default .Chart.AppVersion }}"
+        - name: {{ .Chart.Name }}-dispatch
+          image: "{{ .Values.global.image.repository }}:{{ .Values.global.image.tag | default .Chart.AppVersion }}"
           command:
             - /opt/udpfw/dispatch
-          imagePullPolicy: {{ .Values.udpfw.image.pullPolicy }}
-          {{- with .Values.udpfw.securityContext }}
+          imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          {{- with .Values.dispatch.securityContext }}
           securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:
-            - containerPort: {{ .Values.udpfw.defaultPort }}
+            - containerPort: {{ .Values.dispatch.defaultPort }}
               name: udpfw
               protocol: TCP
-          {{- if .Values.udpfw.ports }}
-          {{- .Values.udpfw.ports | toYaml | nindent 12 }}
+          {{- if .Values.dispatch.ports }}
+          {{- .Values.dispatch.ports | toYaml | nindent 12 }}
           {{- end }}
-          {{- with .Values.udpfw.livenessProbe }}
+          {{- with .Values.dispatch.livenessProbe }}
           livenessProbe: {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.udpfw.readinessProbe }}
+          {{- with .Values.dispatch.readinessProbe }}
           readinessProbe: {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.udpfw.resources }}
+          {{- with .Values.dispatch.resources }}
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.udpfw.envFrom }}
+          {{- with .Values.dispatch.envFrom }}
           envFrom: {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            {{- with .Values.udpfw.env }}
+            {{- with .Values.dispatch.env }}
               {{- toYaml . | nindent 10 }}
             {{- end }}
-            {{- if .Values.udpfw.envDict }}
+            {{- if .Values.dispatch.envDict }}
             {{- range $key, $value := .Values.udpfw.envDict }}
             - name: {{ quote $key }}
               value: {{ quote $value }}
             {{- end }}
             {{- end }}
             - name: UDPFW_DISPATCH_BIND
-              value: {{ include "udpfw.bind" . | quote }}
-            {{- if .Values.udpfw.enableDebugLog }}
+              value: {{ include "dispatch.bind" . | quote }}
+            {{- if .Values.dispatch.enableDebugLog }}
             - name: UDPFW_DISPATCH_DEBUG
               value: "true"
             {{- end }}
-            {{ include "udpfw.pubsub-envs" . | nindent 12 }}
+            {{ include "dispatch.pubsub-envs" . | nindent 12 }}
       {{- with .Values.daemonset.pod.tolerations }}
       tolerations: {{ toYaml .| nindent 8 }}
       {{- end }}

--- a/charts/udpfw/templates/daemonset.yaml
+++ b/charts/udpfw/templates/daemonset.yaml
@@ -36,6 +36,9 @@ spec:
       {{- with .Values.daemonset.pod.useHostNetwork }}
       hostNetwork: true
       {{- end }}
+      {{- with .Values.daemonset.pod.dnsPolicy }}
+      dnsPolicy: {{ . | quote }}
+      {{- end }}
       {{- if or .Values.daemonset.pod.priorityClassCreate .Values.daemonset.pod.priorityClassName }}
       priorityClassName: {{ .Values.daemonset.pod.priorityClassName | default (include "udpfw.fullname" . ) }}
       {{- end }}

--- a/charts/udpfw/templates/daemonset.yaml
+++ b/charts/udpfw/templates/daemonset.yaml
@@ -42,6 +42,8 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.udpfw.image.repository }}:{{ .Values.udpfw.image.tag | default .Chart.AppVersion }}"
+          command:
+            - /opt/udpfw/dispatch
           imagePullPolicy: {{ .Values.udpfw.image.pullPolicy }}
           {{- with .Values.udpfw.securityContext }}
           securityContext: {{- toYaml . | nindent 12 }}

--- a/charts/udpfw/templates/priorityclass.yaml
+++ b/charts/udpfw/templates/priorityclass.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.daemonset.pod.priorityClassCreate}}
 apiVersion: scheduling.k8s.io/v1
-description: Used for UDPFW Components to be scheduled with higher priority.
+description: Used for UDPfw Components to be scheduled with higher priority.
 kind: PriorityClass
 metadata:
   name: {{ .Values.daemonset.pod.priorityClassName | default (include "udpfw.fullname" . ) }}

--- a/charts/udpfw/values.yaml
+++ b/charts/udpfw/values.yaml
@@ -132,6 +132,11 @@ daemonset:
     ## metrics and traces are accepted from any host able to connect to this host.
     useHostNetwork: false
 
+    # daemonset.pod.dnsPolicy -- Pod's DNS policy
+
+    ## See https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+    dnsPolicy: "ClusterFirst"
+
     # daemonset.pod.imagePullSecrets -- Repository pullSecret (ex: specify docker registry credentials)
 
     ## See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod

--- a/charts/udpfw/values.yaml
+++ b/charts/udpfw/values.yaml
@@ -22,7 +22,7 @@ udpfw:
   ## Define the image to work with
   image:
     # udpfw.image.repository -- Repository to use
-    repository: ghcr.io/udpfw/dispatch
+    repository: ghcr.io/udpfw/udpfw
 
     # udpfw.image.tag -- Overrides the global Helm image tag whose default is the chart appVersion
     tag: ""

--- a/charts/udpfw/values.yaml
+++ b/charts/udpfw/values.yaml
@@ -6,44 +6,44 @@ fullnameOverride:  # ""
 
 ## global -- Globally shared configuration
 global:
-  # -- Common labels for the all resources
+  # global.additionalLabels -- Common labels for the all resources
   additionalLabels: {}
   # app: udpfw
 
-## upfw -- Udpfw container configuration
-udpfw:
-
-  # udpfw.defaultPort -- Default port to listen TCP packets
-  defaultPort: 2727
-
-  # udpfw.bindIPV6 -- If the server must bind IPV6 or IPV4 (defaults to IPV4)
-  bindIPV6: false
-
-  ## Define the image to work with
+  # global.image -- Define the image to work with
   image:
-    # udpfw.image.repository -- Repository to use
+    # global.image.repository -- Repository to use
     repository: ghcr.io/udpfw/udpfw
 
-    # udpfw.image.tag -- Overrides the global Helm image tag whose default is the chart appVersion
+    # global.image.tag -- Overrides the global Helm image tag whose default is the chart appVersion
     tag: ""
 
-    # udpfw.image.pullPolicy -- Image pullPolicy
+    # global.image.pullPolicy -- Image pullPolicy
     pullPolicy: IfNotPresent
 
-  # udpfw.enableDebugLog -- Enable log in debug level
+## dispatch -- Dispatch container configuration
+dispatch:
+
+  # dispatch.defaultPort -- Default port to listen TCP packets
+  defaultPort: 2727
+
+  # dispatch.bindIPV6 -- If the server must bind IPV6 or IPV4 (defaults to IPV4)
+  bindIPV6: false
+
+  # dispatch.enableDebugLog -- Enable log in debug level
   enableDebugLog: false
 
-  # udpfw.securityContext -- Allows you to overwrite the default PodSecurityContext on the udpfw container
+  # dispatch.securityContext -- Allows you to overwrite the default PodSecurityContext on the dispatch container
   securityContext:
     capabilities:
       add:
         - NET_ADMIN
     privileged: true
 
-  # udpfw.ports -- Allows to specify extra ports (hostPorts for instance) for this container
+  # dispatch.ports -- Allows to specify extra ports (hostPorts for instance) for this container
   ports: []
 
-  # udpfw.resources -- Resource requests and limits for the this container.
+  # dispatch.resources -- Resource requests and limits for the this container.
   resources: {}
   #  requests:
   #    cpu: 200m
@@ -52,51 +52,51 @@ udpfw:
   #    cpu: 200m
   #    memory: 256Mi
 
-  # udpfw.livenessProbe -- Add liveness probe settings
+  # dispatch.livenessProbe -- Add liveness probe settings
   # @default -- Every 15s / 6 KO / 1 OK
   livenessProbe: {}
 
-  # udpfw.readinessProbe -- Add readiness probe settings
+  # dispatch.readinessProbe -- Add readiness probe settings
   readinessProbe: {}
 
-  # udpfw.env -- Additional environment variables for this container
+  # dispatch.env -- Additional environment variables for this container
   env: []
 
-  # udpfw.envFrom -- Set environment variables specific to container from configMaps and/or secrets
+  # dispatch.envFrom -- Set environment variables specific to container from configMaps and/or secrets
   envFrom: []
   #   - configMapRef:
   #       name: <CONFIGMAP_NAME>
   #   - secretRef:
   #       name: <SECRET_NAME>
 
-  # udpfw.envDict -- Set environment variables specific to this container defined in a dict
+  # dispatch.envDict -- Set environment variables specific to this container defined in a dict
   envDict: {}
   #   <ENV_VAR_NAME>: <ENV_VAR_VALUE>
 
-  # udpfw.nats -- NATS PubSub Server configuration
+  # dispatch.nats -- NATS PubSub Server configuration
   nats:
-    # udpfw.nats.url -- URL for a NATS server (when using NATS for pubsub)
+    # dispatch.nats.url -- URL for a NATS server (when using NATS for pubsub)
     url: ""
-    # udpfw.nats.subscriptionSubject -- Name of a NATS subscription subject where data will be exchanged
-    subscriptionSubject: "udpfw-dispatch-exchange"
-    # udpfw.nats.userCredentials -- NATS user's JWT path
+    # dispatch.nats.subscriptionSubject -- Name of a NATS subscription subject where data will be exchanged
+    subscriptionSubject: "dispatch-dispatch-exchange"
+    # dispatch.nats.userCredentials -- NATS user's JWT path
     userCredentials: ""
-    # udpfw.nats.userCredentialsNkey -- NATS user's private Nkey seed path
+    # dispatch.nats.userCredentialsNkey -- NATS user's private Nkey seed path
     userCredentialsNkey: ""
-    # udpfw.nats.nkeyFromSeed -- NATS user's bare nkey seed path
+    # dispatch.nats.nkeyFromSeed -- NATS user's bare nkey seed path
     nkeyFromSeed: ""
-    # udpfw.nats.rootCA -- Path to Root CA for a self-signed TLS certificate
+    # dispatch.nats.rootCA -- Path to Root CA for a self-signed TLS certificate
     rootCA: ""
-    # udpfw.nats.clientCertificate -- NATS client certificate path
+    # dispatch.nats.clientCertificate -- NATS client certificate path
     clientCertificate: ""
-    # udpfw.nats.clientKey -- NATS client certificate key path
+    # dispatch.nats.clientKey -- NATS client certificate key path
     clientKey: ""
 
-  # udpfw.redis -- Redis PubSub Server configuration
+  # dispatch.redis -- Redis PubSub Server configuration
   redis:
-    # udpfw.redis.url -- Redis URL (when using Redis for pubsub)
+    # dispatch.redis.url -- Redis URL (when using Redis for pubsub)
     url: ""
-    # udpfw.redis.channel -- Redis channel name where data will be exchanged
+    # dispatch.redis.channel -- Redis channel name where data will be exchanged
     channel: "udpfw-dispatch-exchange"
 
 # daemonset -- Daemonset configuration


### PR DESCRIPTION
This bumps the appVersion to v0.1-alpha2, updates the image path, and reflects a change in the image build process, which now creates a single image with both binaries.

Oh, I have also fixed some small details on descriptions and so.